### PR TITLE
application of Telegraf tuning options that helped during Sky upgrades

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -2257,28 +2257,28 @@ package:
         interval = "10s"
         ## Rounds collection interval to 'interval'
         ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
-        round_interval = true
+        round_interval = false
         ## Telegraf will send metrics to outputs in batches of at most
         ## metric_batch_size metrics.
         ## This controls the size of writes that Telegraf sends to output plugins.
-        metric_batch_size = 1000
+        metric_batch_size = 10000
         ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
         ## output, and will flush this buffer on a successful write. Oldest metrics
         ## are dropped first when this buffer fills.
         ## This buffer only fills when writes fail to output plugin(s).
-        metric_buffer_limit = 90000
+        metric_buffer_limit = 200000
         ## Collection jitter is used to jitter the collection by a random amount.
         ## Each plugin will sleep for a random time within jitter before collecting.
         ## This can be used to avoid many plugins querying things like sysfs at the
         ## same time, which can have a measurable effect on the system.
-        collection_jitter = "0s"
+        collection_jitter = "5s"
         ## Default flushing interval for all outputs. You shouldn't set this below
         ## interval. Maximum flush_interval will be flush_interval + flush_jitter
         flush_interval = "10s"
         ## Jitter the flush interval by a random amount. This is primarily to avoid
         ## large write spikes for users running a large number of telegraf instances.
         ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
-        flush_jitter = "0s"
+        flush_jitter = "5s"
         ## By default or when set to "0s", precision will be set to the same
         ## timestamp order as the collection interval, with the maximum being 1s.
         ##   ie, when interval = "10s", precision will be "1s"


### PR DESCRIPTION
application of tunables that helped with scaling, resource usage (less spikey) at Sky

1.) Allow more metrics per iteration (metric_buffer_limit, metric_batch_size) --> otherwise a lot at Sky got dropped by Telegraf
2.) make sure that the metric collection and flushing a lot less spikey, but rather randomly distributed over time (round_internal, jitter settings)

<!--

Please fill in the applicable sections of this template, remove any default text which is not applicable and provide a cohesive, readable pull request description.

This template has some special rules embedded.

1. Mergebot parses JIRA tickets listed in the title of the PR, in the High-Level Description and Corresponding DC/OS tickets (Required) section. Fix Version field of those JIRA tickets is updated upon merge of this PR.

2. Fix Version field will not be updated for the JIRA tickets listed in Related tickets (optional) section.

3. A comment is added to any JIRA tickets mentioned in the title or description upon merge of this PR.

-->

## High-level description

What features does this change enable? What bugs does this change fix?


## Corresponding DC/OS tickets (required)

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Related tickets (optional)

<!--

Please keep the header '## Related tickets (Optional)' if you are adding optional tickets.
Fix Version fields of these JIRAs will not be updated.

-->

  - [DCOS-ID](https://jira.mesosphere.com/browse/DCOS-<number>) JIRA title / short description.


## Checklist for component/package updates:

If you are changing components or packages in DC/OS (e.g. you are bumping the sha or ref of anything underneath `packages`), then in addition to the above please also include:

  - [ ] Change log from the last version integrated (this should be a link to commits for easy verification and review): [example](https://github.com/dcos/dcos-mesos-modules/compare/f6fa27d7c40f4207ba3bb2274e2cfe79b62a395a...6660b90fbbf69a15ef46d0184e36755881d6a5ae)
  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain.
  - [ ] Test Results: [link to CI job test results for component]
  - [ ] Code Coverage (if available): [link to code coverage report]
  

<!--

## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require approvals from any two users on the most recent commit. Any commits added to the pull request after approval will invalidate the approvals.

Reviewers should be:

* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. 
Once a PR has **2 approvals**, **no red reviews**, and **all tests are green** it will be included in the next Merge Train.

-->
